### PR TITLE
SBT failure fix

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,12 +3,12 @@ import sbt.Keys._
 import sbtrelease.ReleasePlugin._
 
 object AdeptBuild extends Build {
-  
+
   val commonSettings = Seq(
     scalaVersion := "2.9.2",
     organization := "org.adept",
     version := {
-      val format = new java.text.SimpleDateFormat("YYYYMMddHHmmss")
+      val format = new java.text.SimpleDateFormat("yyyyMMddHHmmss")
       "0.8.0-ALPHA-"+(format.format(new java.util.Date))
     }
   ) ++ releaseSettings


### PR DESCRIPTION
When i try to run sbt in the repo, i get the following error:

java.lang.IllegalArgumentException: Illegal pattern character 'Y'
at java.text.SimpleDateFormat.compile(SimpleDateFormat.java:768)
at java.text.SimpleDateFormat.initialize(SimpleDateFormat.java:575)
at java.text.SimpleDateFormat.(SimpleDateFormat.java:500)
at java.text.SimpleDateFormat.(SimpleDateFormat.java:475)
at AdeptBuild$$anonfun$3.apply(Build.scala:11)
at AdeptBuild$$anonfun$3.apply(Build.scala:10)
at sbt.Init$Value$$anonfun$apply$6.apply(Settings.scala:329)
at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$constant$1.apply(INode.scala:158)
at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$constant$1.apply(INode.scala:158)
at sbt.EvaluateSettings$MixedNode.evaluate0(INode.scala:177)
at sbt.EvaluateSettings$INode.evaluate(INode.scala:132)
at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$submitEvaluate$1.apply$mcV$sp(INode.scala:64)
at sbt.EvaluateSettings.sbt$EvaluateSettings$$run0(INode.scala:73)
at sbt.EvaluateSettings$$anon$3.run(INode.scala:69)
at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:895)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:918)
at java.lang.Thread.run(Thread.java:662)

Im not sure, but i believe there was a bug in original Build.scala. This fixes the build
