### PR TITLE
Rename ResolutionResult(s) to Context(Value)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ build
 .idea/*.iws
 .idea/workspace.xml
 .idea/tasks.xml
+.idea/modules
+.idea/libraries
+.idea/dictionaries
 
 # Test tmp files:
 tmp

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/target/idea_output" />
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+   <output url="file://$PROJECT_DIR$/target/idea_output" />
   </component>
 </project>
 

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -7,4 +7,3 @@
     </modules>
   </component>
 </project>
-

--- a/adept-core/src/main/scala/adept/lockfile/LockfileConverters.scala
+++ b/adept-core/src/main/scala/adept/lockfile/LockfileConverters.scala
@@ -5,7 +5,7 @@ import adept.artifact.models.ArtifactLocation
 import adept.artifact.models.ArtifactAttribute
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
-import adept.repository.models.ResolutionResult
+import adept.repository.models.ContextValue
 
 private[adept] object LockfileConverters {
     import collection.JavaConverters._
@@ -26,7 +26,7 @@ private[adept] object LockfileConverters {
     val commit = Option(lockfileContext.commit).map(c => adept.repository.models.Commit(c.value))
     val repository = adept.repository.models.RepositoryName(lockfileContext.repository.value)
     val hash = adept.repository.models.VariantHash(lockfileContext.hash.value)
-    ResolutionResult(id, repository, commit, hash)
+    ContextValue(id, repository, commit, hash)
   }
 
   //Helpers to convert from Scala to Java:

--- a/adept-core/src/main/scala/adept/repository/GitRepository.scala
+++ b/adept-core/src/main/scala/adept/repository/GitRepository.scala
@@ -251,8 +251,8 @@ class GitRepository(override val baseDir: File, override val name: RepositoryNam
     }
   }
 
-  private[repository] def usingResolutionResultsInputStream[A](id: Id, hash: VariantHash, commit: Commit)(block: Either[String, Option[InputStream]] => A): A = {
-    usingInputStream(commit, asGitPath(getResolutionResultsFile(id, hash)))(block)
+  private[repository] def usingContextInputStream[A](id: Id, hash: VariantHash, commit: Commit)(block: Either[String, Option[InputStream]] => A): A = {
+    usingInputStream(commit, asGitPath(getContextFile(id, hash)))(block)
   }
 
   private[repository] def usingVariantInputStream[A](id: Id, hash: VariantHash, commit: Commit)(block: Either[String, Option[InputStream]] => A): A = {

--- a/adept-core/src/main/scala/adept/repository/Repository.scala
+++ b/adept-core/src/main/scala/adept/repository/Repository.scala
@@ -24,7 +24,7 @@ object Repository {
   val ReposDirName = "repos"
 
   val JsonFileEnding = "json"
-  val ResolutionResultsFileName = "context." + JsonFileEnding //TODO: change ResolutionResults to Context and ResolutionResult to ContextValue
+  val ContextFileName = "context." + JsonFileEnding
   val InfoMetadataFileName = "info." + JsonFileEnding
   val VariantMetadataFileName = "variant." + JsonFileEnding
   val ArtifactMetadataFileName = "artifact." + JsonFileEnding
@@ -133,12 +133,12 @@ class Repository(val baseDir: File, val name: RepositoryName) { //TODO: had to r
     ensureParentDirs(getVariantFile(id, hash))
   }
 
-  def getResolutionResultsFile(id: Id, hash: VariantHash) = {
-    new File(getVariantHashDir(id, hash), ResolutionResultsFileName)
+  def getContextFile(id: Id, hash: VariantHash) = {
+    new File(getVariantHashDir(id, hash), ContextFileName)
   }
 
-  def ensureResolutionResultsFile(id: Id, hash: VariantHash) = {
-    ensureParentDirs(getResolutionResultsFile(id, hash))
+  def ensureContextFile(id: Id, hash: VariantHash) = {
+    ensureParentDirs(getContextFile(id, hash))
   }
 
   def getArtifactFile(hash: ArtifactHash) = {

--- a/adept-core/src/main/scala/adept/repository/models/ContextValue.scala
+++ b/adept-core/src/main/scala/adept/repository/models/ContextValue.scala
@@ -6,13 +6,12 @@ import play.api.libs.json._
 import play.api.libs.functional.syntax._
 import adept.utils.OrderingHelpers
 
-/** The resolution result for each Id: answers the who we found (the variant hash) and where we found it (commit and repository) */
-@deprecated("ResolutionResult will change name soon") //TODO: change to Context and ContextValues
-case class ResolutionResult(id: Id, repository: RepositoryName, commit: Option[Commit], variant: VariantHash) //TODO: rename variant to hash
+/** The context value for each Id: answers the who we found (the variant hash) and where we found it (commit and repository) */
+case class ContextValue(id: Id, repository: RepositoryName, commit: Option[Commit], variant: VariantHash) //TODO: rename variant to hash
 
-object ResolutionResult {
-  implicit val ordering: Ordering[ResolutionResult] = new Ordering[ResolutionResult] {
-    def compare(x: ResolutionResult, y: ResolutionResult): Int = {
+object ContextValue {
+  implicit val ordering: Ordering[ContextValue] = new Ordering[ContextValue] {
+    def compare(x: ContextValue, y: ContextValue): Int = {
       if (x.repository.value < y.repository.value)
         -1
       else if (x.repository.value > y.repository.value)

--- a/adept-core/src/test/scala/adept/repository/GitLoaderTest.scala
+++ b/adept-core/src/test/scala/adept/repository/GitLoaderTest.scala
@@ -9,7 +9,7 @@ import net.sf.ehcache.CacheManager
 import java.io.File
 import org.scalatest.OptionValues._
 import adept.repository.metadata.VariantMetadata
-import adept.repository.metadata.ResolutionResultsMetadata
+import adept.repository.metadata.ContextMetadata
 import adept.repository.metadata.RepositoryLocationsMetadata
 import adept.repository.metadata.RankingMetadata
 
@@ -19,7 +19,7 @@ class GitLoaderTest extends FunSuite with Matchers {
   import adept.test.CacheUtils._
   import adept.test.OutputUtils._
 
-  def createVersionedResolutionResults(tmpDir: File) = {
+  def createVersionedContext(tmpDir: File) = {
     val repoA = new GitRepository(tmpDir, RepositoryName("com.a"))
     repoA.init()
     val repoB = new GitRepository(tmpDir, RepositoryName("com.b"))
@@ -42,12 +42,12 @@ class GitLoaderTest extends FunSuite with Matchers {
         r.add(RankingMetadata(metadata.hash :: formerRankings).write(v.id, rankId, r))
         val commit = r.commit("Adding: " + v.id)
 
-        ResolutionResult(v.id, r.name, Some(commit), metadata.hash)
+        ContextValue(v.id, r.name, Some(commit), metadata.hash)
     }
   }
 
-//TODO: create a test for unversioned resolution results
-//  def createUnversionedResolutionResults(tmpDir: File) = {
+//TODO: create a test for unversioned context
+//  def createUnversionedContext(tmpDir: File) = {
 //    val repo = new Repository(tmpDir, RepositoryName("com.b"))
 //    val info = Set(
 //      Variant("B", Set(version -> Set("1.0.1"), binaryVersion -> Set("1.0"))),
@@ -60,7 +60,7 @@ class GitLoaderTest extends FunSuite with Matchers {
 //        val rankId = RankingMetadata.DefaultRankId
 //        RankingMetadata(Seq(metadata.hash)).write(v.id, rankId, repo)
 //
-//        ResolutionResult(v.id, repo.name, None, metadata.hash)
+//        ContextValue(v.id, repo.name, None, metadata.hash)
 //    }
 //    initialResults
 //  }
@@ -69,7 +69,7 @@ class GitLoaderTest extends FunSuite with Matchers {
     usingTmpDir { tmpDir =>
       val requirements: Set[Requirement] = Set(
         "A" -> Set(Constraint(binaryVersion, Set("1.0"))))
-      val initialResults = createVersionedResolutionResults(tmpDir)
+      val initialResults = createVersionedContext(tmpDir)
       val loader = new GitLoader(tmpDir, initialResults, cacheManager, progress = progress)
       val result = resolve(requirements, loader)
       checkResolved(result, Set("A", "B"))

--- a/adept-core/src/test/scala/adept/repository/metadata/ContextMetadataTest.scala
+++ b/adept-core/src/test/scala/adept/repository/metadata/ContextMetadataTest.scala
@@ -9,7 +9,7 @@ import adept.repository.models._
 import adept.resolution.models._
 import adept.artifact.models._
 
-class ResolutionResultsMetadataTest extends FunSuite with Matchers {
+class ContextMetadataTest extends FunSuite with Matchers {
   import adept.test.FileUtils.usingTmpDir
 
   test("Create and read repository metadata") {
@@ -18,7 +18,7 @@ class ResolutionResultsMetadataTest extends FunSuite with Matchers {
       repository.init()
       val id = Id("test/foo")
 
-      val repositoryMetadata = ResolutionResultsMetadata(Seq(ResolutionResult(
+      val repositoryMetadata = ContextMetadata(Seq(ContextValue(
           id = id,
           repository = RepositoryName("test"),
           commit = Some(Commit("131321321")),
@@ -29,7 +29,7 @@ class ResolutionResultsMetadataTest extends FunSuite with Matchers {
       repository.add(repositoryMetadata.write(id, hash, repository))
       repository.commit("Added repository")
       import org.scalatest.OptionValues._
-      ResolutionResultsMetadata.read(id, hash, repository, repository.getHead).value shouldEqual repositoryMetadata
+      ContextMetadata.read(id, hash, repository, repository.getHead).value shouldEqual repositoryMetadata
     }
   }
 }

--- a/adept-core/src/test/scala/adept/test/BenchmarkUtils.scala
+++ b/adept-core/src/test/scala/adept/test/BenchmarkUtils.scala
@@ -1,7 +1,7 @@
 package adept.test
 
 import adept.resolution.models.Requirement
-import adept.repository.models.ResolutionResult
+import adept.repository.models.ContextValue
 import adept.hash.Hasher
 import adept.resolution.resolver.models.ResolveResult
 import adept.resolution.models.Variant
@@ -32,7 +32,7 @@ object BenchmarkUtils {
     BenchmarkId(requirements.toString)
   }
 
-  implicit def convertResults(results: Set[ResolutionResult]): BenchmarkId = {
+  implicit def convertResults(results: Set[ContextValue]): BenchmarkId = {
     BenchmarkId(results.toString)
     
   }


### PR DESCRIPTION
As requested in [issue 36](https://github.com/adept-dm/adept/issues/36), rename ResolutionResult to ContextValue and ResolutionResults to Context.
