### PR TITLE
Move adept

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -2,7 +2,11 @@
 <project version="4">
   <component name="ProjectCodeStyleSettingsManager">
     <option name="PER_PROJECT_SETTINGS">
-      <value />
+      <value>
+        <XML>
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+        </XML>
+      </value>
     </option>
     <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (1)" />
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -11,3 +11,4 @@
     </modules>
   </component>
 </project>
+

--- a/adept-core/src/main/scala/adept/Adept.scala
+++ b/adept-core/src/main/scala/adept/Adept.scala
@@ -5,34 +5,35 @@ import net.sf.ehcache.CacheManager
 import org.eclipse.jgit.lib.ProgressMonitor
 import adept.logging.Logging
 import adept.resolution.models.Id
-import adept.repository.models.RepositoryName
+import adept.repository.models.{ContextValue, RepositoryName}
 import adept.resolution.models.Constraint
 import adept.repository.GitRepository
 import adept.repository.metadata.VariantMetadata
-import adept.repository.models.RepositoryLocations
 import adept.repository.metadata.RankingMetadata
 import org.eclipse.jgit.lib.TextProgressMonitor
 import adept.repository.AttributeConstraintFilter
 import adept.repository.Repository
-import adepthub.models.GitSearchResult
 import adept.lockfile.Lockfile
 import java.io.FileOutputStream
 import adept.lockfile.LockfileConverters
-import adept.repository.models.ResolutionResult
 import adept.resolution.models.Variant
 import adept.resolution.models.Requirement
 import adept.repository.GitLoader
 import adept.resolution.Resolver
+import adept.models.GitSearchResult
 
-//TODO: move adept-core
-class Adept(baseDir: File, cacheManager: CacheManager, passphrase: Option[String] = None, progress: ProgressMonitor = new TextProgressMonitor) extends Logging {
+class Adept(baseDir: File, cacheManager: CacheManager, passphrase: Option[String] = None,
+            progress: ProgressMonitor = new TextProgressMonitor) extends Logging {
 
   private[adept] def matches(term: String, id: Id) = {
     (id.value + Id.Sep).contains(term)
   }
 
-  def localResolve(requirements: Set[Requirement], inputContext: Set[ResolutionResult], overriddenInputContext: Set[ResolutionResult], overriddenContext: Set[ResolutionResult], providedVariants: Set[Variant], overrides: Set[ResolutionResult] = Set.empty, unversionedBaseDirs: Set[File] = Set.empty) = {
-    val loader = new GitLoader(baseDir, overriddenContext, cacheManager = cacheManager, unversionedBaseDirs = unversionedBaseDirs, loadedVariants = providedVariants, progress = progress)
+  def localResolve(requirements: Set[Requirement], inputContext: Set[ContextValue], overriddenInputContext:
+  Set[ContextValue], overriddenContext: Set[ContextValue], providedVariants: Set[Variant], overrides:
+                   Set[ContextValue] = Set.empty, unversionedBaseDirs: Set[File] = Set.empty) = {
+    val loader = new GitLoader(baseDir, overriddenContext, cacheManager = cacheManager, unversionedBaseDirs =
+      unversionedBaseDirs, loadedVariants = providedVariants, progress = progress)
     val resolver = new Resolver(loader)
     val result = resolver.resolve(requirements)
     if (result.isResolved) Right(result)
@@ -50,7 +51,8 @@ class Adept(baseDir: File, cacheManager: CacheManager, passphrase: Option[String
     }
   }
 
-  def searchLocalRepository(term: String, name: RepositoryName, constraints: Set[Constraint] = Set.empty): Set[GitSearchResult] = {
+  def searchLocalRepository(term: String, name: RepositoryName, constraints: Set[Constraint] = Set.empty):
+  Set[GitSearchResult] = {
     val repository = new GitRepository(baseDir, name)
     if (repository.exists) {
       val commit = repository.getHead
@@ -61,10 +63,10 @@ class Adept(baseDir: File, cacheManager: CacheManager, passphrase: Option[String
           }.getOrElse(Seq.empty)
           val variants = RankingMetadata.listRankIds(id, repository, commit).flatMap { rankId =>
             val ranking = RankingMetadata.read(id, rankId, repository, commit)
-              .getOrElse(throw new Exception("Could not read rank id: " + (id, rankId, repository.dir.getAbsolutePath, commit)))
+              .getOrElse(throw new Exception("Could not read rank id: " +(id, rankId, repository.dir.getAbsolutePath, commit)))
             ranking.variants.map { hash =>
               VariantMetadata.read(id, hash, repository, commit).map(_.toVariant(id))
-                .getOrElse(throw new Exception("Could not read variant: " + (rankId, id, hash, repository.dir.getAbsolutePath, commit)))
+                .getOrElse(throw new Exception("Could not read variant: " +(rankId, id, hash, repository.dir.getAbsolutePath, commit)))
             }.filter { variant =>
               constraints.isEmpty ||
                 AttributeConstraintFilter.matches(variant.attributes.toSet, constraints)

--- a/adept-core/src/main/scala/adept/Adept.scala
+++ b/adept-core/src/main/scala/adept/Adept.scala
@@ -1,0 +1,94 @@
+package adept
+
+import java.io.File
+import net.sf.ehcache.CacheManager
+import org.eclipse.jgit.lib.ProgressMonitor
+import adept.logging.Logging
+import adept.resolution.models.Id
+import adept.repository.models.RepositoryName
+import adept.resolution.models.Constraint
+import adept.repository.GitRepository
+import adept.repository.metadata.VariantMetadata
+import adept.repository.models.RepositoryLocations
+import adept.repository.metadata.RankingMetadata
+import org.eclipse.jgit.lib.TextProgressMonitor
+import adept.repository.AttributeConstraintFilter
+import adept.repository.Repository
+import adepthub.models.GitSearchResult
+import adept.lockfile.Lockfile
+import java.io.FileOutputStream
+import adept.lockfile.LockfileConverters
+import adept.repository.models.ResolutionResult
+import adept.resolution.models.Variant
+import adept.resolution.models.Requirement
+import adept.repository.GitLoader
+import adept.resolution.Resolver
+
+//TODO: move adept-core
+class Adept(baseDir: File, cacheManager: CacheManager, passphrase: Option[String] = None, progress: ProgressMonitor = new TextProgressMonitor) extends Logging {
+
+  private[adept] def matches(term: String, id: Id) = {
+    (id.value + Id.Sep).contains(term)
+  }
+
+  def localResolve(requirements: Set[Requirement], inputContext: Set[ResolutionResult], overriddenInputContext: Set[ResolutionResult], overriddenContext: Set[ResolutionResult], providedVariants: Set[Variant], overrides: Set[ResolutionResult] = Set.empty, unversionedBaseDirs: Set[File] = Set.empty) = {
+    val loader = new GitLoader(baseDir, overriddenContext, cacheManager = cacheManager, unversionedBaseDirs = unversionedBaseDirs, loadedVariants = providedVariants, progress = progress)
+    val resolver = new Resolver(loader)
+    val result = resolver.resolve(requirements)
+    if (result.isResolved) Right(result)
+    else Left(result)
+  }
+
+  def writeLockfile(lockfile: Lockfile, file: File) = {
+    var fos: FileOutputStream = null
+    try {
+      var fos = new FileOutputStream(file)
+      fos.write(LockfileConverters.toJsonString(lockfile).getBytes)
+      fos.flush()
+    } finally {
+      if (fos != null) fos.close()
+    }
+  }
+
+  def searchLocalRepository(term: String, name: RepositoryName, constraints: Set[Constraint] = Set.empty): Set[GitSearchResult] = {
+    val repository = new GitRepository(baseDir, name)
+    if (repository.exists) {
+      val commit = repository.getHead
+      VariantMetadata.listIds(repository, commit).flatMap { id =>
+        if (matches(term, id)) {
+          val locations = repository.getRemoteUri(GitRepository.DefaultRemote).map { location =>
+            Seq(location)
+          }.getOrElse(Seq.empty)
+          val variants = RankingMetadata.listRankIds(id, repository, commit).flatMap { rankId =>
+            val ranking = RankingMetadata.read(id, rankId, repository, commit)
+              .getOrElse(throw new Exception("Could not read rank id: " + (id, rankId, repository.dir.getAbsolutePath, commit)))
+            ranking.variants.map { hash =>
+              VariantMetadata.read(id, hash, repository, commit).map(_.toVariant(id))
+                .getOrElse(throw new Exception("Could not read variant: " + (rankId, id, hash, repository.dir.getAbsolutePath, commit)))
+            }.filter { variant =>
+              constraints.isEmpty ||
+                AttributeConstraintFilter.matches(variant.attributes.toSet, constraints)
+            }.map {
+              _ -> rankId
+            }
+          }
+
+          variants.map {
+            case (variant, rankId) =>
+              GitSearchResult(variant, rankId, repository.name, commit, locations, isLocal = true)
+          }
+        } else {
+          Set.empty[GitSearchResult]
+        }
+      }
+    } else {
+      Set.empty[GitSearchResult]
+    }
+  }
+
+  def localSearch(term: String, constraints: Set[Constraint] = Set.empty): Set[GitSearchResult] = {
+    Repository.listRepositories(baseDir).flatMap { name =>
+      searchLocalRepository(term, name, constraints)
+    }
+  }
+}

--- a/adept-core/src/main/scala/adept/models/SearchResults.scala
+++ b/adept-core/src/main/scala/adept/models/SearchResults.scala
@@ -1,0 +1,34 @@
+package adept.models
+
+import adept.resolution.models._
+import adept.repository.models.{Commit, RepositoryName, RankId}
+
+
+sealed class SearchResult(val variant: Variant, val rankId: RankId, val repository: RepositoryName,
+  val isImport: Boolean)
+
+case class ImportSearchResult(override val variant: Variant, override val rankId: RankId,
+  override val repository: RepositoryName) extends SearchResult(variant, rankId, repository, isImport = true)
+
+case class GitSearchResult(override val variant: Variant, override val rankId: RankId,
+  override val repository: RepositoryName, commit: Commit, locations: Seq[String], isLocal: Boolean = false)
+  extends SearchResult(variant, rankId, repository, isImport = false)
+
+object GitSearchResult {
+//  implicit val format: Format[GitSearchResult] = {
+//    (
+//      (__ \ "id").format[String] and
+//      (__ \ "variant").format[VariantMetadata] and
+//      (__ \ "rank").format[String] and
+//      (__ \ "repository").format[String] and
+//      (__ \ "commit").format[String] and
+//      (__ \ "locations").format[Seq[String]])({
+//        case (id, variant, rank, repository, commit, locations) =>
+//         GitSearchResult(variant.toVariant(Id(id)), RankId(rank), RepositoryName(repository), Commit(commit), locations)
+//      },
+//        unlift({ gsr: GitSearchResult =>
+//          val GitSearchResult(variant, rank, repository, commit, locations, offline) = gsr
+//          Some(variant.id.value, VariantMetadata.fromVariant(variant), rank.value, repository.value, commit.value, locations)
+//        }))
+//  }
+}

--- a/adept-core/src/main/scala/adept/models/SearchResults.scala
+++ b/adept-core/src/main/scala/adept/models/SearchResults.scala
@@ -13,22 +13,3 @@ case class ImportSearchResult(override val variant: Variant, override val rankId
 case class GitSearchResult(override val variant: Variant, override val rankId: RankId,
   override val repository: RepositoryName, commit: Commit, locations: Seq[String], isLocal: Boolean = false)
   extends SearchResult(variant, rankId, repository, isImport = false)
-
-object GitSearchResult {
-//  implicit val format: Format[GitSearchResult] = {
-//    (
-//      (__ \ "id").format[String] and
-//      (__ \ "variant").format[VariantMetadata] and
-//      (__ \ "rank").format[String] and
-//      (__ \ "repository").format[String] and
-//      (__ \ "commit").format[String] and
-//      (__ \ "locations").format[Seq[String]])({
-//        case (id, variant, rank, repository, commit, locations) =>
-//         GitSearchResult(variant.toVariant(Id(id)), RankId(rank), RepositoryName(repository), Commit(commit), locations)
-//      },
-//        unlift({ gsr: GitSearchResult =>
-//          val GitSearchResult(variant, rank, repository, commit, locations, offline) = gsr
-//          Some(variant.id.value, VariantMetadata.fromVariant(variant), rank.value, repository.value, commit.value, locations)
-//        }))
-//  }
-}


### PR DESCRIPTION
I haven't replaced the play-json serialization scheme for GitSearchResults. How do we solve this, should there be some test that involves (de)serializing GitSearchResults, I mean considering that tests currently pass despite my presumably breaking things?
