### PR TITLE
Add JSON exception class

### DIFF
--- a/adept-core/src/main/scala/adept/exceptions/JsonMissingFieldException.scala
+++ b/adept-core/src/main/scala/adept/exceptions/JsonMissingFieldException.scala
@@ -1,0 +1,5 @@
+package adept.exceptions
+
+case class JsonMissingFieldException(fieldName: String) extends Exception(
+  s"JSON missing field $fieldName") {
+}


### PR DESCRIPTION
Add a general JSON deserialization exception, that adepthub-ext is supposed to use.
